### PR TITLE
CI: notifications for Docker build (Slack webhook or GH issue fallback)

### DIFF
--- a/.github/workflows/ci-notify.yml
+++ b/.github/workflows/ci-notify.yml
@@ -40,9 +40,10 @@ jobs:
         run: |
           title="CI: Build and Push Docker Image completed (${{ steps.prep.outputs.STATUS }})"
           body="Workflow: ${{ steps.prep.outputs.URL }}\nBranch: ${{ steps.prep.outputs.BRANCH }}\nSHA: ${{ steps.prep.outputs.SHA }}"
-          existing=$(gh issue list --state open --search "in:title $title" --json number -q '.[0].number' || true)
+          label="ci-notification"
+          existing=$(gh issue list --state open --label "$label" --json number -q '.[0].number' || true)
           if [ -z "$existing" ]; then
-            gh issue create --title "$title" --body "$body" || true
+            gh issue create --title "$title" --body "$body" --label "$label" || true
           else
             gh issue comment "$existing" --body "$body" || true
           fi

--- a/.github/workflows/ci-notify.yml
+++ b/.github/workflows/ci-notify.yml
@@ -1,0 +1,49 @@
+name: CI Notifications
+
+on:
+  workflow_run:
+    workflows: ["Build and Push Docker Image"]
+    types: [completed]
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Prepare message
+        id: prep
+        run: |
+          echo "STATUS=${{ github.event.workflow_run.conclusion }}" >> $GITHUB_OUTPUT
+          echo "URL=${{ github.event.workflow_run.html_url }}" >> $GITHUB_OUTPUT
+          echo "BRANCH=${{ github.event.workflow_run.head_branch }}" >> $GITHUB_OUTPUT
+          echo "SHA=${{ github.event.workflow_run.head_sha }}" >> $GITHUB_OUTPUT
+
+      - name: Slack notify (if webhook configured)
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        if: ${{ env.SLACK_WEBHOOK_URL != '' }}
+        run: |
+          payload=$(jq -n --arg status "${{ steps.prep.outputs.STATUS }}" \
+                          --arg url "${{ steps.prep.outputs.URL }}" \
+                          --arg branch "${{ steps.prep.outputs.BRANCH }}" \
+                          --arg sha "${{ steps.prep.outputs.SHA }}" \
+                          '{text: ("CI (Build and Push Docker Image) finished with status: " + $status + "\nBranch: " + $branch + "\nSHA: " + $sha + "\n" + $url)}')
+          curl -s -X POST -H 'Content-type: application/json' --data "$payload" "$SLACK_WEBHOOK_URL"
+
+      - name: Fallback GitHub issue update
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        if: ${{ env.SLACK_WEBHOOK_URL == '' }}
+        run: |
+          title="CI: Build and Push Docker Image completed (${{ steps.prep.outputs.STATUS }})"
+          body="Workflow: ${{ steps.prep.outputs.URL }}\nBranch: ${{ steps.prep.outputs.BRANCH }}\nSHA: ${{ steps.prep.outputs.SHA }}"
+          existing=$(gh issue list --state open --search "in:title $title" --json number -q '.[0].number' || true)
+          if [ -z "$existing" ]; then
+            gh issue create --title "$title" --body "$body" || true
+          else
+            gh issue comment "$existing" --body "$body" || true
+          fi
+

--- a/.github/workflows/ci-notify.yml
+++ b/.github/workflows/ci-notify.yml
@@ -30,7 +30,7 @@ jobs:
                           --arg branch "${{ steps.prep.outputs.BRANCH }}" \
                           --arg sha "${{ steps.prep.outputs.SHA }}" \
                           '{text: ("CI (Build and Push Docker Image) finished with status: " + $status + "\nBranch: " + $branch + "\nSHA: " + $sha + "\n" + $url)}')
-          curl -s -X POST -H 'Content-type: application/json' --data "$payload" "$SLACK_WEBHOOK_URL"
+          curl -s --fail -X POST -H 'Content-type: application/json' --data "$payload" "$SLACK_WEBHOOK_URL" || { echo "Slack notification failed!"; exit 1; }
 
       - name: Fallback GitHub issue update
         env:

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -4,13 +4,13 @@ on:
   push:
     branches:
       - meta
-      - production-grade-features
+      - publication-grade-features
     tags:
       - 'v*'
   pull_request:
     branches:
       - meta
-      - production-grade-features
+      - publication-grade-features
   workflow_dispatch:
     inputs:
       push_to_registry:
@@ -65,7 +65,7 @@ jobs:
         with:
           images: ${{ env.IMAGE_NAME }}
           tags: |
-            type=ref,event=branch                # Tag with branch name (e.g., meta, production-grade-features)
+            type=ref,event=branch                # Tag with branch name (e.g., meta, publication-grade-features)
             type=raw,value=latest                # Always tag as 'latest' regardless of branch
             type=ref,event=pr                    # Tag for PR events
             type=semver,pattern={{version}}

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -3,13 +3,13 @@ name: Build and Push Docker Image
 on:
   push:
     branches:
-      - meta
+
       - publication-grade-features
     tags:
       - 'v*'
   pull_request:
     branches:
-      - meta
+
       - publication-grade-features
   workflow_dispatch:
     inputs:

--- a/.github/workflows/mcp-smoke.yml
+++ b/.github/workflows/mcp-smoke.yml
@@ -1,0 +1,18 @@
+name: MCP Smoke Test
+on:
+  push:
+    branches: [publication-grade-features]
+  workflow_dispatch:
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+      - run: npm ci
+      - run: npm run build
+      - name: Run MCP inspector (handshake)
+        run: npx --yes @modelcontextprotocol/inspector@latest --ci node build/index.js


### PR DESCRIPTION
Posts Slack notification via SLACK_WEBHOOK_URL if present; otherwise opens/updates a GitHub issue with run details. Triggers on completion of 'Build and Push Docker Image'.

## Summary by Sourcery

Add a GitHub Actions workflow to notify on completion of the 'Build and Push Docker Image' workflow via Slack or GitHub issues as a fallback.

New Features:
- Trigger a CI Notifications workflow after the Docker image build completes
- Post a detailed Slack message if SLACK_WEBHOOK_URL is configured
- Create or update a GitHub issue with run details when no Slack webhook is provided