### PR TITLE
MCP: Dockerized stdio wrapper for Claude Desktop

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,34 @@ docker build -t meta-analysis-mvp .
 docker run -it --rm meta-analysis-mvp
 ```
 
+### Use with Claude Desktop (Dockerized MCP)
+
+Avoid local R setup by using the Dockerized MCP server via stdio.
+
+1) Build or pull the image
+```bash
+docker build -t meta-analysis-mvp .
+# or pull your registry image if available: docker pull <account>/meta-analysis-mvp:latest
+```
+
+2) Configure Claude Desktop to use the wrapper `scripts/mcp-docker.sh`:
+
+```json
+{
+  "mcpServers": {
+    "meta-analysis-mvp": {
+      "command": "/ABS/PATH/meta-analysis-mvp-standalone/scripts/mcp-docker.sh",
+      "args": [],
+      "transport": "stdio"
+    }
+  }
+}
+```
+
+Optional environment variables:
+- `SESSIONS_DIR`: host directory to persist sessions (mounted to `/app/sessions`)
+- `MCP_IMAGE`/`MCP_TAG`: override image name/tag used by the wrapper
+
 ## Project Structure
 
 ```

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ docker build -t meta-analysis-mvp .
 # or pull your registry image if available: docker pull <account>/meta-analysis-mvp:latest
 ```
 
-2) Configure Claude Desktop to use the wrapper `scripts/mcp-docker.sh`:
+2) Configure Claude Desktop to use the wrapper `scripts/mcp-docker.sh` (path relative to your checked-out project root `meta-analysis-mvp-standalone`):
 
 ```json
 {

--- a/scripts/mcp-docker.sh
+++ b/scripts/mcp-docker.sh
@@ -10,6 +10,12 @@ IMAGE_NAME="${MCP_IMAGE:-meta-analysis-mvp}"
 IMAGE_TAG="${MCP_TAG:-latest}"
 IMAGE="${IMAGE_NAME}:${IMAGE_TAG}"
 
+# Preconditions
+if ! command -v docker >/dev/null 2>&1; then
+  echo "[mcp-docker] Docker CLI not found. Please install Docker Desktop or Docker Engine." >&2
+  exit 1
+fi
+
 # Resolve project root as the directory containing this script's parent
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
@@ -22,9 +28,9 @@ mkdir -p "$HOST_SESSIONS_DIR"
 if ! docker image inspect "$IMAGE" >/dev/null 2>&1; then
   echo "[mcp-docker] Image not found: $IMAGE; attempting docker pull..." >&2
   if ! docker pull "$IMAGE" >/dev/null 2>&1; then
-    echo "[mcp-docker] Pull failed; building image locally as $IMAGE_NAME:latest" >&2
-    docker build -t "$IMAGE_NAME:latest" "$PROJECT_ROOT"
-    IMAGE_TAG="latest"
+    IMAGE_TAG="${MCP_TAG:-latest}"
+    echo "[mcp-docker] Pull failed; building image locally as $IMAGE_NAME:$IMAGE_TAG" >&2
+    docker build -t "$IMAGE_NAME:$IMAGE_TAG" "$PROJECT_ROOT"
     IMAGE="${IMAGE_NAME}:${IMAGE_TAG}"
   fi
 fi

--- a/scripts/mcp-docker.sh
+++ b/scripts/mcp-docker.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Dockerized MCP server runner for Claude Desktop (stdio transport)
+# - Uses an image that contains Node + R + required R packages
+# - Connects stdin/stdout to the containerized server
+# - Mounts a host sessions directory for persistence
+
+IMAGE_NAME="${MCP_IMAGE:-meta-analysis-mvp}"
+IMAGE_TAG="${MCP_TAG:-latest}"
+IMAGE="${IMAGE_NAME}:${IMAGE_TAG}"
+
+# Resolve project root as the directory containing this script's parent
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# Sessions directory
+HOST_SESSIONS_DIR="${SESSIONS_DIR:-$PROJECT_ROOT/sessions}"
+mkdir -p "$HOST_SESSIONS_DIR"
+
+# Ensure image is available: prefer local, then pull, then build
+if ! docker image inspect "$IMAGE" >/dev/null 2>&1; then
+  echo "[mcp-docker] Image not found: $IMAGE; attempting docker pull..." >&2
+  if ! docker pull "$IMAGE" >/dev/null 2>&1; then
+    echo "[mcp-docker] Pull failed; building image locally as $IMAGE_NAME:latest" >&2
+    docker build -t "$IMAGE_NAME:latest" "$PROJECT_ROOT"
+    IMAGE_TAG="latest"
+    IMAGE="${IMAGE_NAME}:${IMAGE_TAG}"
+  fi
+fi
+
+# Run container with stdio connected; no TTY
+exec docker run --rm -i \
+  -v "$HOST_SESSIONS_DIR":/app/sessions \
+  -e SESSIONS_DIR=/app/sessions \
+  "$IMAGE"


### PR DESCRIPTION
## Summary
- Add `scripts/mcp-docker.sh` to run the TypeScript MCP server inside Docker with stdio for Claude Desktop
- Update README with precise configuration to avoid local R setup

## Details
- Wrapper auto-pulls existing image or builds locally if missing
- Mounts host sessions dir and sets `SESSIONS_DIR` accordingly
- Supports overriding image/tag via env vars

## Motivation
Simplify MCP usage in Claude Desktop across environments where R is not installed locally.

## Summary by Sourcery

Add a Dockerized stdio wrapper for the MCP server to simplify usage in Claude Desktop environments without local R, and update README with usage instructions.

New Features:
- Add a Dockerized stdio wrapper script (scripts/mcp-docker.sh) for running the MCP server in Docker with volume mounting and auto pull/build logic

Documentation:
- Document how to build or pull the Docker image and configure Claude Desktop to use the wrapper with optional env vars